### PR TITLE
Simplify warning API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # lifecycle 0.0.0.9000
 
+* Deprecated functions under the control of the developer now warn
+  repeatedly in unit tests.
+
 * Deprecation warnings now record a backtrace. Call
   `lifecycle::last_warnings()` and `lifecycle::last_warning()` to
   print the warnings that occurred during the last command, along with

--- a/R/signal.R
+++ b/R/signal.R
@@ -112,7 +112,7 @@ deprecate_warn <- function(when,
     return(invisible(NULL))
   }
 
-  if (!is_true(peek_option("lifecycle_repeat_warnings")) &&
+  if (!is_true(peek_option("lifecycle_force_warnings")) &&
         env_has(deprecation_env, id)) {
     return(invisible(NULL))
   }
@@ -122,7 +122,7 @@ deprecate_warn <- function(when,
   if (is_true(peek_option("lifecycle_warnings_as_errors"))) {
     deprecate_stop(when, what, with = with, details = details)
   } else {
-    if (!is_true(peek_option("lifecycle_repeat_warnings"))) {
+    if (!is_true(peek_option("lifecycle_force_warnings"))) {
       msg <- paste_line(
         msg,
         silver("This warning is displayed once per session."),

--- a/R/signal.R
+++ b/R/signal.R
@@ -119,7 +119,7 @@ deprecate_warn <- function(when,
 
   env_poke(deprecation_env, id, TRUE);
 
-  if (is_true(peek_option("lifecycle_warnings_as_errors"))) {
+  if (is_true(peek_option("lifecycle_force_errors"))) {
     deprecate_stop(when, what, with = with, details = details)
   } else {
     if (!is_true(peek_option("lifecycle_force_warnings"))) {

--- a/R/signal.R
+++ b/R/signal.R
@@ -72,7 +72,7 @@ deprecate_soft <- function(when,
                            env = caller_env(2)) {
   stopifnot(is_environment(env))
 
-  if (is_true(peek_option("lifecycle_disable_warnings"))) {
+  if (is_true(peek_option("lifecycle_quiet_warnings"))) {
     return(invisible(NULL))
   }
 
@@ -108,7 +108,7 @@ deprecate_warn <- function(when,
   id <- id %||% msg
   stopifnot(is_string(id))
 
-  if (is_true(peek_option("lifecycle_disable_warnings"))) {
+  if (is_true(peek_option("lifecycle_quiet_warnings"))) {
     return(invisible(NULL))
   }
 

--- a/R/signal.R
+++ b/R/signal.R
@@ -88,6 +88,9 @@ deprecate_soft <- function(when,
   if (nzchar(tested_package) &&
         identical(Sys.getenv("NOT_CRAN"), "true") &&
         env_name(topenv(env)) == env_name(ns_env(tested_package))) {
+    # Warn repeatedly in unit tests
+    scoped_options(lifecycle_force_warnings = TRUE)
+
     deprecate_warn(when, what, with = with, details = details, id = id)
     return(invisible(NULL))
   }

--- a/R/signal.R
+++ b/R/signal.R
@@ -39,10 +39,14 @@
 #'   give a unique ID when the message in `details` is built
 #'   programmatically and depends on inputs, or when you'd like to
 #'   deprecate multiple functions but warn only once for all of them.
-#' @param env The environment in which the soft-deprecated function
+#' @param env The environment in which the deprecated function
 #'   was called. A warning is issued if called from the global
 #'   environment. If testthat is running, a warning is also called if
-#'   the retired function was called from the package being tested.
+#'   the deprecated function was called from the package being tested.
+#'
+#'   This typically doesn't need to be specified, unless you call
+#'   `deprecate_soft()` or `deprecate_warn()` from an internal helper.
+#'   In that case, you need to forward the calling environment.
 #'
 #' @seealso [lifecycle()]
 #'
@@ -110,7 +114,8 @@ deprecate_warn <- function(when,
                            what,
                            with = NULL,
                            details = NULL,
-                           id = NULL) {
+                           id = NULL,
+                           env = caller_env(2)) {
   msg <- lifecycle_build_message(when, what, with, details, "deprecate_warn")
 
   id <- id %||% msg
@@ -121,7 +126,8 @@ deprecate_warn <- function(when,
   }
 
   if (!is_true(peek_option("lifecycle_force_warnings")) &&
-        env_has(deprecation_env, id)) {
+        env_has(deprecation_env, id) &&
+        !from_testthat(env)) {
     return(invisible(NULL))
   }
 

--- a/R/signal.R
+++ b/R/signal.R
@@ -76,7 +76,7 @@ deprecate_soft <- function(when,
     return(invisible(NULL))
   }
 
-  if (is_true(peek_option("lifecycle_verbose_soft_deprecation")) ||
+  if (is_true(peek_option("lifecycle_force_warnings")) ||
       env_inherits_global(env)) {
     deprecate_warn(when, what, with = with, details = details, id = id)
     return(invisible(NULL))

--- a/R/verbosity.R
+++ b/R/verbosity.R
@@ -75,7 +75,7 @@ with_lifecycle_silence <- function(expr) {
 scoped_lifecycle_warnings <- function(frame = caller_env()) {
   scoped_options(.frame = frame,
     lifecycle_disable_warnings = FALSE,
-    lifecycle_verbose_soft_deprecation = TRUE,
+    lifecycle_force_warnings = TRUE,
     lifecycle_repeat_warnings = TRUE
   )
 }

--- a/R/verbosity.R
+++ b/R/verbosity.R
@@ -75,8 +75,7 @@ with_lifecycle_silence <- function(expr) {
 scoped_lifecycle_warnings <- function(frame = caller_env()) {
   scoped_options(.frame = frame,
     lifecycle_disable_warnings = FALSE,
-    lifecycle_force_warnings = TRUE,
-    lifecycle_repeat_warnings = TRUE
+    lifecycle_force_warnings = TRUE
   )
 }
 #' @rdname scoped_lifecycle_silence

--- a/R/verbosity.R
+++ b/R/verbosity.R
@@ -90,7 +90,7 @@ with_lifecycle_warnings <- function(expr) {
 scoped_lifecycle_errors <- function(frame = caller_env()) {
   scoped_lifecycle_warnings(frame = frame)
   scoped_options(.frame = frame,
-    lifecycle_warnings_as_errors = TRUE
+    lifecycle_force_errors = TRUE
   )
 }
 #' @rdname scoped_lifecycle_silence

--- a/R/verbosity.R
+++ b/R/verbosity.R
@@ -60,7 +60,7 @@
 #' @export
 scoped_lifecycle_silence <- function(frame = caller_env()) {
   scoped_options(.frame = frame,
-    lifecycle_disable_warnings = TRUE
+    lifecycle_quiet_warnings = TRUE
   )
 }
 #' @rdname scoped_lifecycle_silence
@@ -74,7 +74,7 @@ with_lifecycle_silence <- function(expr) {
 #' @export
 scoped_lifecycle_warnings <- function(frame = caller_env()) {
   scoped_options(.frame = frame,
-    lifecycle_disable_warnings = FALSE,
+    lifecycle_quiet_warnings = FALSE,
     lifecycle_force_warnings = TRUE
   )
 }

--- a/man/deprecate_soft.Rd
+++ b/man/deprecate_soft.Rd
@@ -9,7 +9,8 @@
 deprecate_soft(when, what, with = NULL, details = NULL, id = NULL,
   env = caller_env(2))
 
-deprecate_warn(when, what, with = NULL, details = NULL, id = NULL)
+deprecate_warn(when, what, with = NULL, details = NULL, id = NULL,
+  env = caller_env(2))
 
 deprecate_stop(when, what, with = NULL, details = NULL)
 }
@@ -37,10 +38,14 @@ give a unique ID when the message in \code{details} is built
 programmatically and depends on inputs, or when you'd like to
 deprecate multiple functions but warn only once for all of them.}
 
-\item{env}{The environment in which the soft-deprecated function
+\item{env}{The environment in which the deprecated function
 was called. A warning is issued if called from the global
 environment. If testthat is running, a warning is also called if
-the retired function was called from the package being tested.}
+the deprecated function was called from the package being tested.
+
+This typically doesn't need to be specified, unless you call
+\code{deprecate_soft()} or \code{deprecate_warn()} from an internal helper.
+In that case, you need to forward the calling environment.}
 }
 \description{
 These functions provide three levels of verbosity for deprecated

--- a/tests/testthat/test-lifecycle.R
+++ b/tests/testthat/test-lifecycle.R
@@ -56,7 +56,7 @@ test_that("lifecycle warnings helper enable warnings", {
   retired2 <- function() deprecate_warn("1.0.0", "foo()")
 
   with_options(
-    lifecycle_disable_warnings = TRUE,
+    lifecycle_quiet_warnings = TRUE,
     {
       evalq({
         scoped_lifecycle_warnings()

--- a/tests/testthat/test-lifecycle.R
+++ b/tests/testthat/test-lifecycle.R
@@ -9,13 +9,13 @@ test_that("deprecate_soft() warns when called from global env", {
   env_bind(global_env(), retired = retired)
   on.exit(env_unbind(global_env(), "retired"), add = TRUE)
 
-  with_options(lifecycle_verbose_soft_deprecation = FALSE, {
+  with_options(lifecycle_force_warnings = FALSE, {
     locally({
       expect_no_warning(retired("rlang_test3"), "foo")
     })
   })
 
-  with_options(lifecycle_verbose_soft_deprecation = FALSE, {
+  with_options(lifecycle_force_warnings = FALSE, {
     with_env(global_env(), {
       expect_warning(retired("rlang_test4"), "foo")
     })
@@ -33,13 +33,13 @@ test_that("deprecate_soft() warns when called from package being tested", {
 
 test_that("deprecate_soft() warns when option is set", {
   retired <- function(id) deprecate_soft("1.0.0", "foo()", id = id)
-  with_options(lifecycle_verbose_soft_deprecation = TRUE, {
+  with_options(lifecycle_force_warnings = TRUE, {
     expect_warning(retired("rlang_test5"), "is deprecated")
   })
 })
 
 test_that("deprecate_warn() repeats warnings when option is set", {
-  scoped_options(lifecycle_verbose_soft_deprecation = TRUE)
+  scoped_options(lifecycle_force_warnings = TRUE)
 
   retired1 <- function() deprecate_soft("1.0.0", "foo()", id = "signal repeat")
   retired2 <- function() deprecate_warn("1.0.0", "foo()", id = "warn repeat")
@@ -76,7 +76,7 @@ test_that("lifecycle warnings helper enable warnings", {
 test_that("can disable lifecycle warnings", {
   scoped_lifecycle_silence()
   scoped_options(
-    lifecycle_verbose_soft_deprecation = TRUE,
+    lifecycle_force_warnings = TRUE,
     lifecycle_repeat_warnings = TRUE
   )
 

--- a/tests/testthat/test-lifecycle.R
+++ b/tests/testthat/test-lifecycle.R
@@ -47,10 +47,6 @@ test_that("deprecate_warn() repeats warnings when option is set", {
   expect_warning(retired1(), "is deprecated")
   expect_warning(retired2(), "is deprecated")
 
-  expect_no_warning(retired1())
-  expect_no_warning(retired2())
-
-  scoped_options(lifecycle_repeat_warnings = TRUE)
   expect_warning(retired1(), "is deprecated")
   expect_warning(retired2(), "is deprecated")
 })
@@ -76,8 +72,7 @@ test_that("lifecycle warnings helper enable warnings", {
 test_that("can disable lifecycle warnings", {
   scoped_lifecycle_silence()
   scoped_options(
-    lifecycle_force_warnings = TRUE,
-    lifecycle_repeat_warnings = TRUE
+    lifecycle_force_warnings = TRUE
   )
 
   expect_no_warning(deprecate_soft("1.0.0", "foo()"))
@@ -105,7 +100,7 @@ test_that("once-per-session note is not displayed on repeated warnings", {
   wrn <- catch_cnd(deprecate_warn("1.0.0", "foo()", id = "once-per-session-note"))
   expect_true(grepl("once per session", wrn$message))
 
-  scoped_options(lifecycle_repeat_warnings = TRUE)
+  scoped_options(lifecycle_force_warnings = TRUE)
 
   wrn <- catch_cnd(deprecate_warn("1.0.0", "foo()", id = "once-per-session-no-note"))
   expect_false(grepl("once per session", wrn$message))


### PR DESCRIPTION
1. Reduce number of options from 4 to 3:

- `lifecycle_shush_warnings`
- `lifecycle_force_warnings`
- `lifecycle_force_errors`

2. Warn repeatedly in unit tests. We can only do this for soft-deprecated functions. Is it worth it to add an `env` parameter to `deprecate_warn()` as well, to be able to check for direct usage vs indirect (which shouldn't warn repeatedly)?