### PR TITLE
Only warn if option is wrong

### DIFF
--- a/R/verbosity.R
+++ b/R/verbosity.R
@@ -55,10 +55,11 @@ lifecycle_verbosity <- function() {
 
   if (!is_string(opt, c("quiet", "default", "warning", "error"))) {
     options(lifecycle_verbosity = "default")
-    abort(glue::glue(
+    warn(glue::glue(
       "
       The `lifecycle_verbosity` option must be set to one of:
       \"quiet\", \"default\", \"warning\", or \"error\".
+      Resetting to \"default\".
       "
     ))
   }

--- a/tests/testthat/test-verbosity.R
+++ b/tests/testthat/test-verbosity.R
@@ -4,7 +4,7 @@ test_that("verbosity option is validated", {
   opt <- with_options(lifecycle_verbosity = NULL, lifecycle_verbosity())
   expect_identical(opt, "default")
 
-  expect_error(
+  expect_warning(
     with_options(lifecycle_verbosity = NA, lifecycle_verbosity()),
     "must be set to one of"
   )


### PR DESCRIPTION
Otherwise rerunning the same client code will give different results, without an indication regarding the reason.