### PR TITLE
Support partial deprecation of arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # lifecycle 0.1.0.9000
 
+* New syntax `"foo(arg = 'can not be a baz')"` to describe that specific inputs
+  for an argument are deprecated (#30, @krlmlr).
+
 * New `is_present()` function to test whether the caller has supplied a
   `deprecated()` function.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # lifecycle 0.1.0.9000
 
-* New syntax `"foo(arg = 'can not be a baz')"` to describe that specific inputs
+* New syntax `"foo(arg = 'can\\'t be a baz')"` to describe that specific inputs
   for an argument are deprecated (#30, @krlmlr).
 
 * New `is_present()` function to test whether the caller has supplied a

--- a/man/deprecate_soft.Rd
+++ b/man/deprecate_soft.Rd
@@ -86,6 +86,9 @@ deprecate_warn("1.0.0", "foo()")
 # A deprecated argument `arg`:
 deprecate_warn("1.0.0", "foo(arg = )")
 
+# A partially deprecated argument `arg`:
+deprecate_warn("1.0.0", "foo(arg = 'must be a scalar integer')")
+
 # A deprecated function with a function replacement:
 deprecate_warn("1.0.0", "foo()", "bar()")
 

--- a/tests/testthat/output/test-signal-message-args.txt
+++ b/tests/testthat/output/test-signal-message-args.txt
@@ -32,3 +32,9 @@ Deprecated argument with argument replacement (different function, different pac
 
 The `quux` argument of `foo()` is deprecated as of aaa 1.0.0.
 Please use the `foofy` argument of `zzz::bar()` instead.
+
+
+Deprecated argument with reason
+===============================
+
+The `quux` argument of `foo()` can not be a baz as of aaa 1.0.0.

--- a/tests/testthat/output/test-signal-message-args.txt
+++ b/tests/testthat/output/test-signal-message-args.txt
@@ -37,4 +37,4 @@ Please use the `foofy` argument of `zzz::bar()` instead.
 Deprecated argument with reason
 ===============================
 
-The `quux` argument of `foo()` can not be a baz as of aaa 1.0.0.
+The `quux` argument of `foo()` can't be a baz as of aaa 1.0.0.

--- a/tests/testthat/test-signal.R
+++ b/tests/testthat/test-signal.R
@@ -56,6 +56,9 @@ test_that("deprecation messages are constructed for arguments", {
 
     cat_ruler("Deprecated argument with argument replacement (different function, different package)")
     cat_line(lifecycle_build_message("1.0.0", "aaa::foo(quux = )", "zzz::bar(foofy = )", signaller = "deprecate_stop"))
+
+    cat_ruler("Deprecated argument with reason")
+    cat_line(lifecycle_build_message("1.0.0", "aaa::foo(quux = 'can not be a baz')", signaller = "deprecate_stop"))
   })
 })
 

--- a/tests/testthat/test-signal.R
+++ b/tests/testthat/test-signal.R
@@ -58,7 +58,7 @@ test_that("deprecation messages are constructed for arguments", {
     cat_line(lifecycle_build_message("1.0.0", "aaa::foo(quux = )", "zzz::bar(foofy = )", signaller = "deprecate_stop"))
 
     cat_ruler("Deprecated argument with reason")
-    cat_line(lifecycle_build_message("1.0.0", "aaa::foo(quux = 'can not be a baz')", signaller = "deprecate_stop"))
+    cat_line(lifecycle_build_message("1.0.0", "aaa::foo(quux = 'can\\'t be a baz')", signaller = "deprecate_stop"))
   })
 })
 

--- a/vignettes/lifecycle.Rmd
+++ b/vignettes/lifecycle.Rmd
@@ -129,6 +129,12 @@ deprecate_warn("1.0.0", "mypkg::foo(arg = )")
 deprecate_warn("1.0.0", "mypkg::foo(arg = )", "mypkg::foo(new = )")
 ```
 
+An argument can be partially deprecated by disallowing certain input types:
+
+```{r}
+deprecate_warn("1.0.0", "mypkg::foo(arg = 'must be a scalar integer')")
+```
+
 lifecycle also provides the `deprecated()` sentinel to use as default argument. This provides self-documentation for your users and makes it possible for external tools to determine which arguments are deprecated. Test whether the argument was supplied by the caller with `lifecycle::is_present()`:
 
 ```{r}


### PR DESCRIPTION
I'd like to have something like this in tibble in ~10 places.

``` r
lifecycle::deprecate_warn("1.0.0", "mypkg::foo(arg = 'must be a scalar integer')")
#> Warning: The `arg` argument of `foo()` must be a scalar integer as of mypkg 1.0.0.
#> This warning is displayed once per session.
#> Call `lifecycle::last_warnings()` to see where this warning was generated.
```

<sup>Created on 2020-01-02 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Closes #30.