### PR TITLE
Add URL to pkgdown website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,6 @@ Suggests:
     testthat (>= 2.1.0)
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.0.2
-URL: https://github.com/r-lib/lifecycle
+URL: https://lifecycle.r-lib.org/, https://github.com/r-lib/lifecycle
 BugReports: https://github.com/r-lib/lifecycle/issues
 VignetteBuilder: knitr


### PR DESCRIPTION
* This allows direct navigation to the online docs from the CRAN page
* This allows [cross-linking from other pkgdown websites](https://pkgdown.r-lib.org/articles/linking.html#across-packages)