### PR TITLE
hand env to deprecate_warn() when called from deprecate_soft()

### DIFF
--- a/R/signal-deprecated.R
+++ b/R/signal-deprecated.R
@@ -87,7 +87,7 @@ deprecate_soft <- function(when,
   }
 
   if (verbosity %in% c("warning", "error") || env_inherits_global(env)) {
-    deprecate_warn(when, what, with = with, details = details, id = id)
+    deprecate_warn(when, what, with = with, details = details, id = id, env = env)
     return(invisible(NULL))
   }
 
@@ -95,7 +95,7 @@ deprecate_soft <- function(when,
     # Warn repeatedly in unit tests
     scoped_options(lifecycle_verbosity = "warning")
 
-    deprecate_warn(when, what, with = with, details = details, id = id)
+    deprecate_warn(when, what, with = with, details = details, id = id, env = env)
     return(invisible(NULL))
   }
 


### PR DESCRIPTION
Otherwise the message detects `lifecycle` as the package, e.g. seeing this when testing `AzureKusto`: 

```
test_translate.r:210: warning: group_by() followed by summarize() with multiple summarizations generates one summarize clause in presence of hints
The `.dots` argument of `group_by()` is deprecated as of lifecycle 1.0.0.
```


