### PR TITLE
Improve warnings in indirect usages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,16 @@
 # lifecycle (development version)
 
+* Indirect usages of `deprecate_warn()` no longer warn repeatedly,
+  even if `always = TRUE` (#135).
+
 * In tests, `deprecate_soft()` will only warn if the deprecated function
   is called directly from the package being tested, not one of its dependencies.
-  This ensures that you only see the warning when it's your responsibility to 
+  This ensures that you only see the warning when it's your responsibility to
   do something about it (#134).
-  
-* `deprecate_soft()` will never warn when called on CRAN, ensuring that soft 
+
+* `deprecate_soft()` will never warn when called on CRAN, ensuring that soft
   deprecation will never break a reverse dependency (#134).
-  
+
 * Soft deprecations now only warn every 8 hours in non-package code (#134).
 
 # lifecycle 1.0.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # lifecycle (development version)
 
+* Indirect usages of deprecated features now mention the package that
+  likely used the deprecated feature and recommends contacting the
+  authors (#135).
+
 * Indirect usages of `deprecate_warn()` no longer warn repeatedly,
   even if `always = TRUE` (#135).
 

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -126,9 +126,11 @@ deprecate_soft <- function(when,
 }
 
 #' @rdname deprecate_soft
-#' @param always If `FALSE`, the default, will warn every 8 hours.
-#'   If `TRUE`, will always warn. Only use `always = TRUE` after at least
-#'   one release with the default.
+#' @param always If `FALSE`, the default, will warn every 8 hours.  If
+#'   `TRUE`, will always warn in direct usages. Indirect usages keep
+#'   warning every 8 hours to avoid disrupting users who can't fix the
+#'   issue. Only use `always = TRUE` after at least one release with
+#'   the default.
 #' @export
 deprecate_warn <- function(when,
                            what,

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -107,7 +107,6 @@ deprecate_soft <- function(when,
   invisible(switch(
     verbosity,
     quiet = NULL,
-    error = deprecate_stop0(msg),
     warning = ,
     default =
       if (direct) {
@@ -121,7 +120,8 @@ deprecate_soft <- function(when,
           direct = TRUE,
           user_env = user_env
         )
-      }
+      },
+    error = deprecate_stop0(msg)
   ))
 }
 
@@ -147,7 +147,6 @@ deprecate_warn <- function(when,
   invisible(switch(
     verbosity,
     quiet = NULL,
-    error = deprecate_stop0(msg),
     warning = ,
     default = {
       direct <- is_direct(user_env)
@@ -161,7 +160,8 @@ deprecate_warn <- function(when,
         direct = direct,
         user_env = user_env
       )
-    }
+    },
+    error = deprecate_stop0(msg),
   ))
 }
 

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -128,7 +128,8 @@ deprecate_warn <- function(when,
                            details = NULL,
                            id = NULL,
                            always = FALSE,
-                           env = caller_env()) {
+                           env = caller_env(),
+                           user_env = caller_env(2)) {
   msg <- NULL # trick R CMD check
   msg %<~% lifecycle_message(when, what, with, details, env, "deprecate_warn")
   signal_stage("deprecated", what)
@@ -141,7 +142,7 @@ deprecate_warn <- function(when,
     error = deprecate_stop0(msg),
     warning = ,
     default = {
-      always <- always || verbosity == "warning"
+      always <- (always || verbosity == "warning") && is_direct(user_env)
       trace <- trace_back(bottom = caller_env())
       deprecate_warn0(msg, id, trace, always = always)
     }

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -102,18 +102,19 @@ deprecate_soft <- function(when,
   signal_stage("deprecated", what)
 
   verbosity <- lifecycle_verbosity()
-  if (verbosity == "quiet") {
-    NULL
-  } else if (verbosity %in% c("warning", "default")) {
-    if (is_direct(user_env)) {
-      always <- verbosity == "warning"
-      deprecate_warn0(msg, id, trace_back(bottom = caller_env()), always = always)
-    }
-  } else if (verbosity == "error") {
-    deprecate_stop0(msg)
-  }
 
-  invisible(NULL)
+  invisible(switch(
+    verbosity,
+    quiet = NULL,
+    error = deprecate_stop0(msg),
+    warning = ,
+    default =
+      if (is_direct(user_env)) {
+        always <- verbosity == "warning"
+        trace <- trace_back(bottom = caller_env())
+        deprecate_warn0(msg, id, trace, always = always)
+      }
+  ))
 }
 
 #' @rdname deprecate_soft
@@ -133,16 +134,18 @@ deprecate_warn <- function(when,
   signal_stage("deprecated", what)
 
   verbosity <- lifecycle_verbosity()
-  if (verbosity == "quiet") {
-    NULL
-  } else if (verbosity %in% c("default", "warning")) {
-    always <- always || verbosity == "warning"
-    deprecate_warn0(msg, id, trace_back(bottom = caller_env()), always = always)
-  } else if (verbosity == "error") {
-    deprecate_stop0(msg)
-  }
 
-  invisible(NULL)
+  invisible(switch(
+    verbosity,
+    quiet = NULL,
+    error = deprecate_stop0(msg),
+    warning = ,
+    default = {
+      always <- always || verbosity == "warning"
+      trace <- trace_back(bottom = caller_env())
+      deprecate_warn0(msg, id, trace, always = always)
+    }
+  ))
 }
 
 #' @rdname deprecate_soft

--- a/man/deprecate_soft.Rd
+++ b/man/deprecate_soft.Rd
@@ -23,7 +23,8 @@ deprecate_warn(
   details = NULL,
   id = NULL,
   always = FALSE,
-  env = caller_env()
+  env = caller_env(),
+  user_env = caller_env(2)
 )
 
 deprecate_stop(when, what, with = NULL, details = NULL, env = caller_env())

--- a/man/deprecate_soft.Rd
+++ b/man/deprecate_soft.Rd
@@ -67,9 +67,11 @@ These are only needed if you're calling \verb{deprecate_*()} from an internal
 helper, in which case you should forward \code{env = caller_env()} and
 \code{user_env = caller_env(2)}.}
 
-\item{always}{If \code{FALSE}, the default, will warn every 8 hours.
-If \code{TRUE}, will always warn. Only use \code{always = TRUE} after at least
-one release with the default.}
+\item{always}{If \code{FALSE}, the default, will warn every 8 hours.  If
+\code{TRUE}, will always warn in direct usages. Indirect usages keep
+warning every 8 hours to avoid disrupting users who can't fix the
+issue. Only use \code{always = TRUE} after at least one release with
+the default.}
 }
 \value{
 \code{NULL}, invisibly.

--- a/tests/testthat/_snaps/deprecate.md
+++ b/tests/testthat/_snaps/deprecate.md
@@ -1,25 +1,30 @@
 # deprecate_warn() only warns repeatedly if always = TRUE
 
     Code
-      deprecate()
+      direct()
     Condition
       Warning:
       `foo()` was deprecated in lifecycle 1.0.0.
     Code
-      deprecate()
+      direct()
+      indirect()
+      indirect()
 
 ---
 
     Code
-      deprecate(always = TRUE)
+      direct(always = TRUE)
     Condition
       Warning:
       `foo()` was deprecated in lifecycle 1.0.0.
     Code
-      deprecate(always = TRUE)
+      direct(always = TRUE)
     Condition
       Warning:
       `foo()` was deprecated in lifecycle 1.0.0.
+    Code
+      indirect(always = TRUE)
+      indirect(always = TRUE)
 
 # what deprecation messages are readable
 

--- a/tests/testthat/_snaps/deprecate.md
+++ b/tests/testthat/_snaps/deprecate.md
@@ -26,6 +26,16 @@
       indirect(always = TRUE)
       indirect(always = TRUE)
 
+# indirect usage recommends contacting authors
+
+    Code
+      indirect()
+    Condition
+      Warning:
+      `foo()` was deprecated in lifecycle 1.0.0.
+      i The deprecated feature was likely used in the base package.
+        Please report the issue to the authors.
+
 # what deprecation messages are readable
 
     Code

--- a/tests/testthat/helper-lifecycle.R
+++ b/tests/testthat/helper-lifecycle.R
@@ -1,4 +1,3 @@
-
 expect_lifecycle_defunct <- function(object, ...) {
   expect_error(object, class = "defunctError")
 }
@@ -28,4 +27,14 @@ spec_data <- function(fn = NULL,
     reason = reason,
     from = from
   )
+}
+
+new_callers <- function(deprecated_feature, env = caller_env()) {
+  direct <- inject(function(...) (!!deprecated_feature)(...))
+  indirect <- inject(function(...) (!!deprecated_feature)(...))
+
+  environment(direct) <- global_env()
+  environment(indirect) <- ns_env("base")
+
+  list(direct, indirect)
 }

--- a/tests/testthat/helper-zeallot.R
+++ b/tests/testthat/helper-zeallot.R
@@ -1,0 +1,34 @@
+# nocov start --- compat-zeallot --- 2020-11-23
+
+# This drop-in file implements a simple version of zeallot::`%<-%`.
+# Please find the most recent version in rlang's repository.
+
+
+`%<-%` <- function(lhs, value) {
+  lhs <- substitute(lhs)
+  env <- caller_env()
+
+  if (!is_call(lhs, "c")) {
+    abort("The left-hand side of `%<-%` must be a call to `c()`.")
+  }
+
+  vars <- as.list(lhs[-1])
+
+  if (length(value) != length(vars)) {
+    abort("The left- and right-hand sides of `%<-%` must be the same length.")
+  }
+
+  for (i in seq_along(vars)) {
+    var <- vars[[i]]
+    if (!is_symbol(var)) {
+      abort(paste0("Element ", i, " of the left-hand side of `%<-%` must be a symbol."))
+    }
+
+    env[[as_string(var)]] <- value[[i]]
+  }
+
+  invisible(value)
+}
+
+
+# nocov end

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -36,6 +36,18 @@ test_that("deprecate_warn() only warns repeatedly if always = TRUE", {
   })
 })
 
+test_that("indirect usage recommends contacting authors", {
+  on.exit(env_unbind(deprecation_env, "test"))
+  local_options(lifecycle_verbosity = "default")
+
+  deprecated_feature <- function(...) deprecate_warn("1.0.0", "foo()", id = "test", ...)
+  c(direct, indirect) %<-% new_callers(deprecated_feature)
+
+  expect_snapshot({
+    indirect()
+  })
+})
+
 test_that("quiet suppresses _soft and _warn", {
   local_options(lifecycle_verbosity = "quiet")
 


### PR DESCRIPTION
Branched from #136.
Closes #135.

In case of indirect usage:

- Don't warn every time.
- Recommend reaching out to the authors of the package that used the deprecated feature.