### PR TITLE
Make `is_direct()` work the same way in CMD check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,9 +12,6 @@
   This ensures that you only see the warning when it's your responsibility to
   do something about it (#134).
 
-* `deprecate_soft()` will never warn when called on CRAN, ensuring that soft
-  deprecation will never break a reverse dependency (#134).
-
 * Soft deprecations now only warn every 8 hours in non-package code (#134).
 
 # lifecycle 1.0.2

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -367,12 +367,18 @@ env_inherits_global <- function(env) {
 # same as the package that called
 from_testthat <- function(env) {
   tested_package <- Sys.getenv("TESTTHAT_PKG")
+  if (!nzchar(tested_package)) {
+    return(FALSE)
+  }
+
+  top <- topenv(env)
+  if (!is_namespace(top)) {
+    return(FALSE)
+  }
 
   # Test for environment names rather than reference/contents because
   # testthat clones the namespace
-  nzchar(tested_package) &&
-    identical(Sys.getenv("NOT_CRAN"), "true") &&
-    env_name(topenv(env)) == paste0("namespace:", tested_package)
+  identical(ns_env_name(top), tested_package)
 }
 
 needs_warning <- function(id, call = caller_env()) {


### PR DESCRIPTION
Closes #142

I think it should work the same way:

- Interactively (topenv is global)
- In `test()`
- In CMD check