### PR TITLE
Use new argument in example

### DIFF
--- a/vignettes/communicate.Rmd
+++ b/vignettes/communicate.Rmd
@@ -343,7 +343,7 @@ add_two <- function(x, y, na_rm = TRUE, na.rm = deprecated()) {
     na_rm <- na.rm
   }
   
-  add_two(x, y, na.rm = na_rm)
+  add_two(x, y, na_rm = na_rm)
 }
 ```
 


### PR DESCRIPTION
In the text. it says to use the new argument, `na_rm`. but the call is still with `na.rm`