### PR TITLE
Only generate the `trace_back()` as needed

### DIFF
--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -115,13 +115,13 @@ deprecate_soft <- function(when,
     default =
       if (direct) {
         always <- verbosity == "warning"
-        trace <- trace_back(bottom = caller_env())
+        trace_env <- caller_env()
         deprecate_warn0(
           msg,
           id,
-          trace,
           always = always,
           direct = TRUE,
+          trace_env = trace_env,
           user_env = user_env
         )
       },
@@ -157,13 +157,13 @@ deprecate_warn <- function(when,
     default = {
       direct <- is_direct(user_env)
       always <- direct && (always || verbosity == "warning")
-      trace <- trace_back(bottom = caller_env())
+      trace_env <- caller_env()
       deprecate_warn0(
         msg,
         id,
-        trace,
         always = always,
         direct = direct,
+        trace_env = trace_env,
         user_env = user_env
       )
     },
@@ -188,10 +188,10 @@ deprecate_stop <- function(when,
 
 deprecate_warn0 <- function(msg,
                             id = NULL,
-                            trace = NULL,
                             always = FALSE,
                             direct = FALSE,
                             call = caller_env(),
+                            trace_env = caller_env(),
                             user_env = caller_env(2)) {
   id <- id %||% paste_line(msg)
   if (!always && !needs_warning(id, call = call)) {
@@ -242,6 +242,9 @@ deprecate_warn0 <- function(msg,
 
     footer
   }
+
+  trace <- trace_back(bottom = trace_env)
+
   wrn <- new_deprecated_warning(msg, trace, footer = footer)
 
   # Record muffled warnings if testthat is running because it


### PR DESCRIPTION
I was investigating https://github.com/tidyverse/dplyr/issues/6897 with dev lifecycle installed and discovered a lot of the remaining time spent in _repeated_ calls to `deprecate_soft()` and `deprecate_warn()` with `always = FALSE` is in generating the `trace_back()`, which we throw away every single time except for the very first one.

I've moved the `trace_back()` call _after_ our early exit, which cuts the time for `deprecate_soft()` in half again

```r
# trigger it once
lifecycle::deprecate_soft("1.1.0", "fn()", "fn2()")

f <- function() {
  lifecycle::deprecate_soft("1.1.0", "fn()", "fn2()")
}
g <- function() {
  for (i in 1:1000) {
    f()
  }  
}
bench::system_time(g())
```

Current dev main

```
process    real 
  712ms   703ms
```

This PR

```
process    real 
  385ms   379ms 
```