### PR TITLE
Speed up `deprecate_soft()` / `deprecate_warn()`, actually warn after 8 hours, and interpolate `({arg})`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Depends:
     R (>= 3.6)
 Imports:
     cli (>= 3.4.0),
-    glue,
     rlang (>= 1.1.0)
 Suggests:
     covr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # lifecycle (development version)
 
+* `deprecate_soft()` and `deprecate_warn()` are faster thanks to some internal refactoring.
+
 * `deprecate_soft()` now actually warns after every 8 hours.
 
 * Improvements to `lint_lifecycle()` and `lint_tidyverse_lifecycle()` (@AshesITR):

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # lifecycle (development version)
 
+* `deprecate_soft()` now actually warns after every 8 hours.
+
 * Improvements to `lint_lifecycle()` and `lint_tidyverse_lifecycle()` (@AshesITR):
   * Updated to support lintr >= 3.0.0 (#178).
   * Fixed default `pattern=` argument to only find R files (#165).

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -306,24 +306,22 @@ lifecycle_message <- function(when,
 }
 
 lifecycle_message_what <- function(what, when) {
-  glue_what <- function(x) glue::glue_data(what, x)
-
   if (!inherits(what$fn, "AsIs")) {
     what$fn <- fun_label(what$fn)
   }
 
   if (is_null(what$arg)) {
     if (what$from == "deprecate_stop") {
-      glue_what("{ fn } was deprecated in { pkg } { when } and is now defunct.")
+      sprintf("%s was deprecated in %s %s and is now defunct.", what$fn, what$pkg, when)
     } else {
-      glue_what("{ fn } was deprecated in { pkg } { when }.")
+      sprintf("%s was deprecated in %s %s.", what$fn, what$pkg, when)
     }
   } else {
     if (what$from == "deprecate_stop" && is_null(what$reason)) {
-      glue_what("The `{ arg }` argument of { fn } was deprecated in { pkg } { when } and is now defunct.")
+      sprintf("The `%s` argument of %s was deprecated in %s %s and is now defunct.", what$arg, what$fn, what$pkg, when)
     } else {
       what$reason <- what$reason %||% "is deprecated"
-      glue_what("The `{ arg }` argument of { fn } { reason } as of { pkg } { when }.")
+      sprintf("The `%s` argument of %s %s as of %s %s.", what$arg, what$fn, what$reason, what$pkg, when)
     }
   }
 }
@@ -337,21 +335,19 @@ fun_label <- function(fn) {
 }
 
 lifecycle_message_with <- function(with, what) {
-  glue_with <- function(x) glue::glue_data(with, x)
-
   if (inherits(with$fn, "AsIs")) {
-    glue_with("Please use { fn } instead.")
+    sprintf("Please use %s instead.", with$fn)
   } else {
     if (!is_null(with$pkg) && what$pkg != with$pkg) {
-      with$fn <- glue_with("{ pkg }::{ fn }")
+      with$fn <- sprintf("%s::%s", with$pkg, with$fn)
     }
 
     if (is_null(with$arg)) {
-      glue_with("Please use `{ fn }()` instead.")
+      sprintf("Please use `%s()` instead.", with$fn)
     } else if (what$fn == with$fn) {
-      glue_with("Please use the `{ arg }` argument instead.")
+      sprintf("Please use the `%s` argument instead.", with$arg)
     } else {
-      glue_with("Please use the `{ arg }` argument of `{ fn }()` instead.")
+      sprintf("Please use the `%s` argument of `%s()` instead.", with$arg, with$fn)
     }
   }
 }

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -408,5 +408,7 @@ needs_warning <- function(id, call = caller_env()) {
   }
 
   # Warn every 8 hours
-  (Sys.time() - last) > (8 * 60 * 60)
+  # Must unclass to ensure we always compare in units of seconds, also much
+  # faster this way.
+  (unclass(Sys.time()) - unclass(last)) > (8 * 60 * 60)
 }

--- a/R/signal.R
+++ b/R/signal.R
@@ -28,9 +28,9 @@ signal_stage <- function(stage, what, with = NULL, env = caller_env()) {
   what <- spec(what, env = env)
 
   if (is_null(what$arg)) {
-    msg <- glue::glue_data(what, "{fn}() is {stage}")
+    msg <- sprintf("%s() is %s", what$fn, stage)
   } else {
-    msg <- glue::glue_data(what, "{fn}(arg) is {stage}")
+    msg <- sprintf("%s(%s) is %s", what$fn, what$arg, stage)
   }
 
   if (!is_null(with)) {

--- a/R/signal.R
+++ b/R/signal.R
@@ -24,7 +24,7 @@
 #' }
 #' foofy(1, 2, 3)
 signal_stage <- function(stage, what, with = NULL, env = caller_env()) {
-  stage <- arg_match(stage, c("experimental", "superseded", "deprecated"))
+  stage <- arg_match0(stage, c("experimental", "superseded", "deprecated"))
   what <- spec(what, env = env)
 
   if (is_null(what$arg)) {

--- a/R/verbosity.R
+++ b/R/verbosity.R
@@ -52,13 +52,15 @@ lifecycle_verbosity <- function() {
 
   if (!is_string(opt, c("quiet", "default", "warning", "error"))) {
     options(lifecycle_verbosity = "default")
-    warn(glue::glue(
-      "
-      The `lifecycle_verbosity` option must be set to one of:
-      \"quiet\", \"default\", \"warning\", or \"error\".
-      Resetting to \"default\".
-      "
-    ))
+
+    message <- paste(
+      sep = " ",
+      "The `lifecycle_verbosity` option must be set to one of:",
+      "\"quiet\", \"default\", \"warning\", or \"error\".",
+      "Resetting to \"default\"."
+    )
+    
+    warn(message)
   }
 
   opt

--- a/tests/testthat/_snaps/signal.md
+++ b/tests/testthat/_snaps/signal.md
@@ -7,7 +7,7 @@
     Code
       (expect_condition(signal_stage("superseded", "foo(bar)")))
     Output
-      <lifecycle_stage: foo(arg) is superseded>
+      <lifecycle_stage: foo(bar) is superseded>
 
 # signal_stage supports with
 
@@ -19,6 +19,6 @@
     Code
       (expect_condition(signal_stage("superseded", "foo(bar=)", "foo(baz=)")))
     Output
-      <lifecycle_stage: foo(arg) is superseded
+      <lifecycle_stage: foo(bar) is superseded
       Please use the `baz` argument instead.>
 

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -213,8 +213,9 @@ test_that("needs_warning works as expected", {
   env_poke(deprecation_env, "test", Sys.time())
   expect_false(needs_warning("test"))
 
+  # More than 8 hours
   env_poke(deprecation_env, "test", Sys.time() - 9 * 60 * 60)
-  expect_false(needs_warning("test"))
+  expect_true(needs_warning("test"))
 
   env_poke(deprecation_env, "test", "x")
   expect_snapshot_error(needs_warning("test"))


### PR DESCRIPTION
The 3 commits here are self contained. Look at them individually to easily understand this PR.

The goal of this PR is to improve performance of `deprecate_soft()` and friends. We've been plagued by poor performance here for years, and it really hurts when used repeatedly in a `group_by()` + `mutate()` where the function used in `mutate()` is deprecated or has a deprecated argument.

I've been able to make it ~3x faster by:
- Swapping `glue_data()` for `sprintf()`, at the cost of ergonomics. But this is the biggest win, so I think it is worth it.
- Swapping `arg_match()` for `arg_match0()`
- Avoiding `-.POSIXct` and difftime operations when computing the 8 hour time diff, which was doing the wrong thing anyways!!

``` r
cross::bench_branches(\() {
  library(lifecycle)
  
  # trigger the 8 hour warning once
  deprecate_soft("1.1.0", I("my thing"), details = "for this reason")

  bench::mark(
    deprecate_soft("1.1.0", I("my thing"), details = "for this reason")
  )
})
#> # A tibble: 2 × 7
#>   branch               expression                    min  median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                <bch:expr>                <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 fix/deprecation-time "deprecate_soft(\"1.1.0\…  73.1µs  75.3µs    12802.    8.56KB     168.
#> 2 main                 "deprecate_soft(\"1.1.0\… 224.8µs 231.5µs     4229.    8.56KB     176.
```

I got here by analyzing this profvis output

```r
profvis::profvis(for (i in 1:100000) lifecycle::deprecate_soft("1.5.0", I("a thing"), details = "another thing"))
```

<img width="496" height="747" alt="Screenshot 2025-10-03 at 10 32 46 AM" src="https://github.com/user-attachments/assets/999929a0-0b08-443a-b0b9-bb97680485cb" />
