### PR TITLE
Fix long line CRAN check note

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ Config/Needs/website: tidyverse/tidytemplate, usethis
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/lint.R
+++ b/R/lint.R
@@ -192,12 +192,17 @@ lint_tidyverse_lifecycle <- function(
 #' @param which Vector of lifecycle statuses to lint.
 #' @param symbol_is_undesirable Also lint symbol usages, e.g. `lapply(x, is_na)`?
 #'
-#' @examples
-#'
-#' lintr::lint(text = "is_na(x)", linters = lifecycle_linter(packages = "rlang"))
-#' lintr::lint(text = "lapply(x, is_na)", linters = lifecycle_linter(packages = "rlang", symbol_is_undesirable = TRUE))
-#'
 #' @export
+#' @examples
+#' lintr::lint(
+#'   text = "is_na(x)",
+#'   linters = lifecycle_linter(packages = "rlang")
+#' )
+#' lintr::lint(
+#'   text = "lapply(x, is_na)",
+#'   linters = lifecycle_linter(packages = "rlang",
+#'   symbol_is_undesirable = TRUE)
+#' )
 lifecycle_linter <- function(
   packages = tidyverse::tidyverse_packages(),
   which = c(

--- a/man/lifecycle_linter.Rd
+++ b/man/lifecycle_linter.Rd
@@ -65,8 +65,13 @@ annotations for an installed package.
 }
 }
 \examples{
-
-lintr::lint(text = "is_na(x)", linters = lifecycle_linter(packages = "rlang"))
-lintr::lint(text = "lapply(x, is_na)", linters = lifecycle_linter(packages = "rlang", symbol_is_undesirable = TRUE))
-
+lintr::lint(
+  text = "is_na(x)",
+  linters = lifecycle_linter(packages = "rlang")
+)
+lintr::lint(
+  text = "lapply(x, is_na)",
+  linters = lifecycle_linter(packages = "rlang",
+  symbol_is_undesirable = TRUE)
+)
 }


### PR DESCRIPTION
```
❯ checking Rd line widths ... NOTE
  Rd file 'lifecycle_linter.Rd':
    \examples lines wider than 100 characters:
       lintr::lint(text = "lapply(x, is_na)", linters = lifecycle_linter(packages = "rlang", symbol_is_undesirable = TRUE))
  
  These lines will be truncated in the PDF manual.
```