### PR TITLE
Bypass `signal()` to avoid validation and cli related overhead

### DIFF
--- a/R/signal.R
+++ b/R/signal.R
@@ -28,25 +28,28 @@ signal_stage <- function(stage, what, with = NULL, env = caller_env()) {
   what <- spec(what, env = env)
 
   if (is_null(what$arg)) {
-    msg <- sprintf("%s() is %s", what$fn, stage)
+    message <- sprintf("%s() is %s", what$fn, stage)
   } else {
-    msg <- sprintf("%s(%s) is %s", what$fn, what$arg, stage)
+    message <- sprintf("%s(%s) is %s", what$fn, what$arg, stage)
   }
 
   if (!is_null(with)) {
     with <- spec(with, NULL, "signal_stage")
-    msg <- paste0(msg, "\n", lifecycle_message_with(with, what))
+    message <- paste0(message, "\n", lifecycle_message_with(with, what))
   }
 
-  signal(
-    msg,
-    "lifecycle_stage",
+  # Much faster than calling `rlang::signal()` directly.
+  # `message` is already formatted so we don't need to worry about cli.
+  cnd_signal(cnd(
+    class = "lifecycle_stage",
+    message = message,
     stage = stage,
     package = what$pkg,
     function_nm = what$fn,
     argument = what$arg,
-    reason = what$reason
-  )
+    reason = what$reason,
+    use_cli_format = FALSE
+  ))
 }
 
 #' Deprecated functions for signalling experimental and lifecycle stages


### PR DESCRIPTION
Another ~30% faster by avoiding `.rlang_cli_format_fallback()` and getting to specify `cli(use_cli_format = FALSE)` explicitly

``` r
cross::bench_branches(\() {
  library(lifecycle)
  
  # trigger the 8 hour warning once
  deprecate_soft("1.1.0", I("my thing"), details = "for this reason")

  bench::mark(
    deprecate_soft("1.1.0", I("my thing"), details = "for this reason")
  )
})
#> # A tibble: 2 × 7
#>   branch                   expression                                 min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                    <bch:expr>                              <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 feature/manual-condition "deprecate_soft(\"1.1.0\", I(\"my thin… 48.5µs 51.1µs    18777.    8.56KB     160.
#> 2 main                     "deprecate_soft(\"1.1.0\", I(\"my thin… 73.3µs 75.6µs    12899.    8.56KB     169.
```

<img width="500" height="192" alt="Screenshot 2025-10-03 at 10 59 09 AM" src="https://github.com/user-attachments/assets/d2cbd451-bf24-402e-83e1-fc3fa60b3e62" />
<img width="528" height="148" alt="Screenshot 2025-10-03 at 10 59 16 AM" src="https://github.com/user-attachments/assets/98abe0dd-35c8-4864-a878-0910589c5cc6" />
