### PR TITLE
Test and talk about why `id` is awesome

### DIFF
--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -43,11 +43,14 @@
 #'   which will be converted to a [bulleted list][cli::cli_bullets].
 #'   By default, info bullets are used. Provide a named vectors to
 #'   override.
-#' @param id The id of the deprecation. A warning is issued only once
-#'   for each `id`. Defaults to the generated message, but you should
-#'   give a unique ID when the message in `details` is built
-#'   programmatically and depends on inputs, or when you'd like to
-#'   deprecate multiple functions but warn only once for all of them.
+#' @param id The id of the deprecation. A warning is issued only once for each
+#'   `id`. Defaults to the generated message, but you should provide a unique
+#'   `id` when the message in `details` is built programmatically and depends on
+#'   inputs, or when you'd like to deprecate multiple functions but warn only
+#'   once for all of them. Repeated calls to `deprecate_soft()` and
+#'   `deprecate_warn()` are also much faster if you supply an `id` because it
+#'   avoids spending time generating the message only to immediately exit if the
+#'   once per session warning has already been thrown before.
 #' @param env,user_env Pair of environments that define where `deprecate_*()`
 #'   was called (used to determine the package name) and where the function
 #'   called the deprecating function was called (used to determine if

--- a/man/deprecate_soft.Rd
+++ b/man/deprecate_soft.Rd
@@ -56,11 +56,14 @@ which will be converted to a \link[cli:cli_bullets]{bulleted list}.
 By default, info bullets are used. Provide a named vectors to
 override.}
 
-\item{id}{The id of the deprecation. A warning is issued only once
-for each \code{id}. Defaults to the generated message, but you should
-give a unique ID when the message in \code{details} is built
-programmatically and depends on inputs, or when you'd like to
-deprecate multiple functions but warn only once for all of them.}
+\item{id}{The id of the deprecation. A warning is issued only once for each
+\code{id}. Defaults to the generated message, but you should provide a unique
+\code{id} when the message in \code{details} is built programmatically and depends on
+inputs, or when you'd like to deprecate multiple functions but warn only
+once for all of them. Repeated calls to \code{deprecate_soft()} and
+\code{deprecate_warn()} are also much faster if you supply an \code{id} because it
+avoids spending time generating the message only to immediately exit if the
+once per session warning has already been thrown before.}
 
 \item{env, user_env}{Pair of environments that define where \verb{deprecate_*()}
 was called (used to determine the package name) and where the function

--- a/tests/testthat/_snaps/deprecate.md
+++ b/tests/testthat/_snaps/deprecate.md
@@ -186,6 +186,18 @@
       Error:
       ! `details` must be a character vector, not a number.
 
+# lifecycle message is never generated when an `id` is supplied and we've already warned
+
+    Code
+      deprecate_soft(when = stop("when"), what = I("needed by signal_stage()"), with = stop(
+        "with"), details = stop("details"), env = stop("env"), id = "test")
+
+---
+
+    Code
+      deprecate_warn(when = stop("when"), what = I("needed by signal_stage()"), with = stop(
+        "with"), details = stop("details"), env = stop("env"), id = "test")
+
 # needs_warning works as expected
 
     Code

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -213,6 +213,41 @@ test_that("checks input types", {
   expect_snapshot(lifecycle_message("1", details = 1), error = TRUE)
 })
 
+test_that("lifecycle message is never generated when an `id` is supplied and we've already warned", {
+  # This is an important test for performance reasons. Supplying an `id` makes
+  # repeated calls to `deprecate_soft()` and `deprecate_warn()` much faster by
+  # avoiding message generation via `lifecycle_message()`.
+
+  on.exit(env_unbind(deprecation_env, c("test")))
+  local_options(lifecycle_verbosity = "default")
+
+  # Mock having already warned this session
+  env_poke(deprecation_env, "test", TRUE)
+
+  # These arguments are never touched again if we supply an `id`,
+  # we expect silence in the snapshot
+  expect_snapshot({
+    deprecate_soft(
+      when = stop("when"),
+      what = I("needed by signal_stage()"),
+      with = stop("with"),
+      details = stop("details"),
+      env = stop("env"),
+      id = "test"
+    )
+  })
+  expect_snapshot({
+    deprecate_warn(
+      when = stop("when"),
+      what = I("needed by signal_stage()"),
+      with = stop("with"),
+      details = stop("details"),
+      env = stop("env"),
+      id = "test"
+    )
+  })
+})
+
 # helpers -----------------------------------------------------------------
 
 test_that("env_inherits_global works for simple cases", {


### PR DESCRIPTION
The `id` argument in combination with the `msg %<~%` delayed assign operator used internally is awesome. It lets us totally avoid `lifecycle_message()` in `deprecate_soft()` and `deprecate_warn()`, which are expensive.

This PR documents this usage of `id`, and adds a test so we hopefully don't regress on this in the future. I also added a comment in https://github.com/r-lib/lifecycle/commit/26fa727bfb24779dc498bc7a6f8864337b10be40 about this.

``` r
# Without `id` (CRAN vs this PR with all the other fixes so far)

cross::bench_versions(pkgs = c("lifecycle", "r-lib/lifecycle#197"), \() {
  library(lifecycle)
  
  # trigger the 8 hour warning once
  deprecate_soft("1.1.0", I("my thing"), details = "for this")

  bench::mark(
    deprecate_soft("1.1.0", I("my thing"), details = "for this"),
    iterations = 100000
  )
})
#> # A tibble: 2 × 7
#>   pkg                 expression                      min  median `itr/sec` mem_alloc `gc/sec`
#>   <chr>               <bch:expr>                    <bch> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 lifecycle           "deprecate_soft(\"1.1.0\", I… 224µs 239.8µs     4046.    8.55KB     42.0
#> 2 r-lib/lifecycle#197 "deprecate_soft(\"1.1.0\", I…  43µs  44.4µs    21872.    8.56KB     59.7
```

```r
# With `id` (CRAN vs this PR with all the other fixes so far)

cross::bench_versions(pkgs = c("lifecycle", "r-lib/lifecycle#197"), \() {
  library(lifecycle)
  
  # trigger the 8 hour warning once
  deprecate_soft("1.1.0", I("my thing"), details = "for this", id = "foo")

  bench::mark(
    deprecate_soft("1.1.0", I("my thing"), details = "for this", id = "foo"),
    iterations = 100000
  )
})
#> # A tibble: 2 × 7
#>   pkg                 expression                      min  median `itr/sec` mem_alloc `gc/sec`
#>   <chr>               <bch:expr>                  <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 lifecycle           "deprecate_soft(\"1.1.0\",…   145µs 154.9µs     6316.    8.55KB     44.1
#> 2 r-lib/lifecycle#197 "deprecate_soft(\"1.1.0\",…  31.7µs  33.1µs    29172.    8.56KB     67.0
```

When a once per session message has already been thrown and `id` is supplied, we are getting very close to "just early exiting" - almost all of the time is now in `signalCondition()` due to it not being as lazy as we'd hope.

```r
profvis::profvis(for (i in 1:100000) deprecate_soft("1.1.0", I("my thing"), details = "for this", id = "foo"))
```

<img width="499" height="138" alt="Screenshot 2025-10-03 at 1 46 49 PM" src="https://github.com/user-attachments/assets/c50c6967-b549-44d3-9553-0e2702f70ef1" />

<img width="499" height="328" alt="Screenshot 2025-10-03 at 1 47 43 PM" src="https://github.com/user-attachments/assets/94be3b0d-6b33-4dea-aad5-379c5b014477" />

