### PR TITLE
Dark hackery

### DIFF
--- a/R/signal.R
+++ b/R/signal.R
@@ -26,7 +26,8 @@
 signal_stage <- function(stage, what, with = NULL, env = caller_env()) {
   stage <- arg_match0(stage, c("experimental", "superseded", "deprecated"))
   cnd <- new_lifecycle_stage_cnd(stage, what, with, env)
-  cnd_signal(cnd)
+  # cnd_signal(cnd)
+  .Internal(.signalCondition(cnd, "dummy", NULL))
 }
 
 new_lifecycle_stage_cnd <- function(stage, what, with, env) {


### PR DESCRIPTION
@hadley if you combine `id` into the mix which avoids `lifecycle_message()` generation in the main path (see #197), then pretty much all of the remaining overhead moves into `cnd_signal()` and `signalCondition()` not being as lazy as we'd like. So this dark hackery starts to look more interesting...

``` r
cross::bench_branches(\() {
  library(lifecycle)
  
  # trigger the per session warning once
  deprecate_soft("1.1.0", I("my thing"), details = "for this", id = "foo")

  bench::mark(
    deprecate_soft("1.1.0", I("my thing"), details = "for this", id = "foo"),
    iterations = 100000
  )
})
#> # A tibble: 2 × 7
#>   branch               expression                      min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                <bch:expr>                   <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 feature/dark-hackery "deprecate_soft(\"1.1.0\", … 13.2µs 13.9µs    68580.    8.56KB    102. 
#> 2 main                 "deprecate_soft(\"1.1.0\", … 31.7µs 33.2µs    28957.    8.56KB     66.5
```

I'm still not entirely sure how safe this is, because I think there is a path where `"dummy"` would get shown to the user as some error message if they somehow promote our `lifecycle_stage` condition to an error?

https://github.com/wch/r-source/blob/f200c30b1a20dfa9394d7facff616e9cb2a42c6d/src/main/errors.c#L1904-L1909
