### PR TITLE
Optimize the fast path of `lifecycle_verbosity()`

### DIFF
--- a/R/verbosity.R
+++ b/R/verbosity.R
@@ -48,7 +48,11 @@
 NULL
 
 lifecycle_verbosity <- function() {
-  opt <- peek_option("lifecycle_verbosity") %||% "default"
+  opt <- peek_option("lifecycle_verbosity")
+
+  if (is_null(opt)) {
+    return("default")
+  }
 
   if (!is_string(opt, c("quiet", "default", "warning", "error"))) {
     options(lifecycle_verbosity = "default")


### PR DESCRIPTION
Avoid the not required `is_string()` check